### PR TITLE
fixed navigating to rules fragment polluting nav back stack

### DIFF
--- a/app/src/main/java/ru/itis/team1/summer2023/lab/RulesFragment.kt
+++ b/app/src/main/java/ru/itis/team1/summer2023/lab/RulesFragment.kt
@@ -76,7 +76,7 @@ class RulesFragment: Fragment(R.layout.fragment_rules) {
     private fun navigateButton(button: MaterialButton) {
         button.text = resources.getString(R.string.got_it_message)
         button.setOnClickListener{
-            findNavController().navigate(R.id.action_rulesFragment_to_mainFragment)
+            findNavController().popBackStack()
         }
     }
     private fun restoreMessages(messages: HashMap<TextView, ImageView>) {


### PR DESCRIPTION
each move from rules fragment back to main fragment was leaving an entry in back stack, so using the back button from main fragment was navigating to rules fragment, which should not happen